### PR TITLE
removed deprecated use case of Buffer constructor

### DIFF
--- a/lib/streams/jsonToObjectTransform.js
+++ b/lib/streams/jsonToObjectTransform.js
@@ -23,7 +23,7 @@ class JsonToObjectTransform extends Transform {
                 value.type === 'Buffer' &&
                 'data' in value &&
                 Array.isArray(value.data)) {
-                return new Buffer(value.data);
+                return Buffer.from(value.data);
             }
             return value;
         }));

--- a/test/streams/transform.js
+++ b/test/streams/transform.js
@@ -55,7 +55,7 @@ describe('Transform Streams', () => {
                 Assertions.assertTransform(done, this, new JsonToObjectTransform());
             });
 
-            it_object('should return an object when given', new Buffer('hello'), function (done) {
+            it_object('should return an object when given', Buffer.from('hello'), function (done) {
 
                 Assertions.assertTransform(done, this, new JsonToObjectTransform());
             });
@@ -156,7 +156,7 @@ describe('Transform Streams', () => {
                 Assertions.assertTransform(done, this, new StringToJsonBufferTransform(), true);
             });
 
-            it_object('should return json string when given', new Buffer('hello'), function (done) {
+            it_object('should return json string when given', Buffer.from('hello'), function (done) {
 
                 Assertions.assertTransform(done, this, new StringToJsonBufferTransform(), true);
             });


### PR DESCRIPTION
## Description

Replaced deprecated `new Buffer()` syntax with `Buffer.from()` and `Buffer.alloc()` where applicable.  

## Related Issue

* -#4

## Motivation and Context
To keep up with NodeJs API.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus-cli/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.